### PR TITLE
Fix map setup for Catan

### DIFF
--- a/src/app/components/MapGenerator.js
+++ b/src/app/components/MapGenerator.js
@@ -28,10 +28,23 @@ const MapGenerator = ({ numPlayers, noSameResources, noSameNumbers, scarceResour
       6: [3, 4, 5, 6, 5, 4, 3]
     };
 
+    const numberTokens = {
+      4: { 2: 1, 3: 2, 4: 2, 5: 2, 6: 2, 8: 2, 9: 2, 10: 2, 11: 2, 12: 1 },
+      5: { 2: 2, 3: 3, 4: 3, 5: 3, 6: 3, 8: 3, 9: 3, 10: 3, 11: 3, 12: 2 },
+      6: { 2: 2, 3: 3, 4: 3, 5: 3, 6: 3, 8: 3, 9: 3, 10: 3, 11: 3, 12: 2 }
+    };
+
     const resourceList = [];
     for (const [resource, count] of Object.entries(resources[numPlayers])) {
       for (let i = 0; i < count; i++) {
         resourceList.push(resource);
+      }
+    }
+
+    const numberTokenList = [];
+    for (const [number, count] of Object.entries(numberTokens[numPlayers])) {
+      for (let i = 0; i < count; i++) {
+        numberTokenList.push(number);
       }
     }
 
@@ -41,7 +54,8 @@ const MapGenerator = ({ numPlayers, noSameResources, noSameNumbers, scarceResour
       const rowTiles = [];
       for (let i = 0; i < row; i++) {
         const resource = resourceList.splice(Math.floor(Math.random() * resourceList.length), 1)[0];
-        rowTiles.push({ id: id++, resource, number: Math.floor(Math.random() * 12) + 1 });
+        const number = resource === 'desert' ? null : numberTokenList.splice(Math.floor(Math.random() * numberTokenList.length), 1)[0];
+        rowTiles.push({ id: id++, resource, number });
       }
       generatedMap.push(rowTiles);
     }

--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -79,3 +79,17 @@
   font-weight: bold;
   color: #333;
 }
+
+.number-token {
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  background-color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: bold;
+  color: black;
+}


### PR DESCRIPTION
Update Catan map setup to follow specified counts of resource tiles, desert tiles, and number tokens for both 4-player and 5-6 player configurations.

* **Map Generation Logic**: Modify `src/app/components/MapGenerator.js` to include logic for number tokens according to the specified counts for both 4-player and 5-6 player configurations. Ensure the correct distribution of resource tiles and desert tiles as specified. Assign number tokens to tiles based on the specified counts.
* **Styles**: Add styles for number tokens to be displayed on map tiles in `src/app/styles/global.css`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/krushiraj/catan-map-generator/pull/4?shareId=bc8ae560-3ebb-41ac-b71a-da9734b7118f).