### PR TITLE
Fix map generator to account for constraints

### DIFF
--- a/src/app/components/MapGenerator.js
+++ b/src/app/components/MapGenerator.js
@@ -48,13 +48,40 @@ const MapGenerator = ({ numPlayers, noSameResources, noSameNumbers, scarceResour
       }
     }
 
+    // Handle scarce resource constraint
+    if (scarceResource && scarceResource !== 'random') {
+      const scarceCount = Math.floor(resourceList.length / 5);
+      resourceList = resourceList.filter(resource => resource !== scarceResource);
+      for (let i = 0; i < scarceCount; i++) {
+        resourceList.push(scarceResource);
+      }
+    } else if (scarceResource === 'random') {
+      const randomResource = Object.keys(resources[numPlayers]).filter(resource => resource !== 'desert')[Math.floor(Math.random() * 5)];
+      const scarceCount = Math.floor(resourceList.length / 5);
+      resourceList = resourceList.filter(resource => resource !== randomResource);
+      for (let i = 0; i < scarceCount; i++) {
+        resourceList.push(randomResource);
+      }
+    }
+
     const generatedMap = [];
     let id = 1;
     for (const row of layout[numPlayers]) {
       const rowTiles = [];
       for (let i = 0; i < row; i++) {
-        const resource = resourceList.splice(Math.floor(Math.random() * resourceList.length), 1)[0];
-        const number = resource === 'desert' ? null : numberTokenList.splice(Math.floor(Math.random() * numberTokenList.length), 1)[0];
+        let resource;
+        let number;
+
+        // Ensure no same resources touch
+        do {
+          resource = resourceList.splice(Math.floor(Math.random() * resourceList.length), 1)[0];
+        } while (noSameResources && rowTiles.some(tile => tile.resource === resource));
+
+        // Ensure no same numbers touch
+        do {
+          number = resource === 'desert' ? null : numberTokenList.splice(Math.floor(Math.random() * numberTokenList.length), 1)[0];
+        } while (noSameNumbers && rowTiles.some(tile => tile.number === number));
+
         rowTiles.push({ id: id++, resource, number });
       }
       generatedMap.push(rowTiles);


### PR DESCRIPTION
Update `generateHexMap` function to account for `preventResourceTouch` and `preventNumberTouch` constraints.

* Add logic to handle `scarceResource` constraint by adjusting the resource list based on the specified scarce resource or a random resource.
* Ensure resources and numbers are distributed according to specified constraints by checking for adjacent tiles with the same resource or number.
* Modify the resource and number selection process to prevent same resources or numbers from touching each other when respective constraints are enabled.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/krushiraj/catan-map-generator/pull/5?shareId=7d7637c0-8874-4330-9642-e72905d0a98c).